### PR TITLE
Updated the load() function in the parser to return the G object that it creates.

### DIFF
--- a/src/lua.jison
+++ b/src/lua.jison
@@ -116,7 +116,8 @@ script
       "};\n" +
       "{\n" +
       $2.simple_form + "\n" +
-      "}\n";
+      "}\n" +
+	  "return G;\n";
   }
   ;
 


### PR DESCRIPTION
While trying to use lua+parser.js I noticed that the load() function created by lua_load() would never actually return the G variable that it creates, meaning that I couldn't access the data. With this change my usage is

var luaLoaderFunction = lua_load(luaScript);
var luaObject = luaLoaderFunction();

Let me know if I've misunderstood how to use lua_load() and this fix is incorrect. Thanks.
