### PR TITLE
Why is unpack broken?

### DIFF
--- a/src/lualib.js
+++ b/src/lualib.js
@@ -677,7 +677,7 @@ var lua_core = {
     if (j == null) {
       j = list.length;
     }
-    throw new ReturnValues(list.uints.slice(i - 1, j), 2);
+    throw new ReturnValues(list.uints.slice(i - 1, j), 1);
   },
   "_VERSION": "Lua 5.1",
   "xpcall": function () {


### PR DESCRIPTION
This patch fixes the Lua unpack function by modifying the value passed to the ReturnValues constructor function. It appears that your standard library requires the parameter "count" to be set to 1 or else it does not handle the thrown results exception...

Please weigh in if I'm missing something here. Thanks!
