### PR TITLE
Table corruption when changing arraystate.

### DIFF
--- a/src/lualib.js
+++ b/src/lualib.js
@@ -32,6 +32,7 @@ function ensure_arraymode(table) {
   if (!table.arraymode) {
     var newuints = [];
     for (var i in table.uints) {
+      i = parseInt(i);
       if (table.uints[i] != null) {
         newuints[i - 1] = table.uints[i];
       }
@@ -44,6 +45,7 @@ function ensure_notarraymode(table) {
   if (table.arraymode) {
     var newuints = {};
     for (var i in table.uints) {
+      i = parseInt(i);
       if (table.uints[i] != null) {
         newuints[i + 1] = table.uints[i];
       }


### PR DESCRIPTION
In strange cases 'i' is a string. i + 1 becomes a string operation, and doesn't work as expected.

This causes tables to get corrupted.

Example lua script that suffers from this:

a = {1,2,3,4,5,6,7,8,9}
a[1] = 1337

for i=1, 9 do
  print(a[i])
end

This will print
1337
null
null
null
null
null
..
