### PR TITLE
more detailed error messages

### DIFF
--- a/src/lualib.js
+++ b/src/lualib.js
@@ -185,10 +185,11 @@ function lua_rawcall(func, args) {
     throw e;
   }
 }
-function lua_call(func, args) {
+function lua_call(func, args, origin) {
   if (typeof func == "function") {
     return lua_rawcall(func, args);
   } else {
+    if (func == null) throw new Error("attempt to call nil ("+String(origin)+")");
     var h = func.metatable && func.metatable.str["__call"];
     if (h != null) {
       return lua_rawcall(h, [func].concat(args));
@@ -198,7 +199,9 @@ function lua_call(func, args) {
   }
 }
 function lua_mcall(obj, methodname, args) {
-  return lua_call(lua_tableget(obj, methodname), [obj].concat(args));
+  var fun = lua_tableget(obj, methodname);
+  if (fun == null) throw new Error("attempt to call method '"+String(methodname)+"' (a nil value)");
+  return lua_call(fun, [obj].concat(args));
 }
 function lua_eq(op1, op2) {
   if (typeof op1 != typeof op2) {


### PR DESCRIPTION
I'm often running into not-yet-implemented stuff when trying my something in my luajs-based webplayer. 
Finding out what's missing is a pain, so i started experimenting with error messages.

example 1

```
local myobj = {}
myobj:MissingMethod(1,2,3)
-- luajs master : TypeError: Cannot read property 'metatable' of null
-- lua native : attempt to call method 'MissingMethod' (a nil value)
-- luajs changed (lualib.js only) : Error: attempt to call method 'MissingMethod' (a nil value)
```

example 2

```
local myfun1 = nil
myfun1()
-- luajs master : TypeError: Cannot read property 'metatable' of null
-- lua native : attempt to call local 'myfun1' (a nil value)
-- luajs changed (lualib.js only) : Error: attempt to call nil (undefined)
-- luajs changed (lualib.js + bison(see below)) : Error: attempt to call nil (_myfun1_)
```

example 3

```
local love = { graphics = {} } 
love.graphics.setDefaultImageFilter('linear','nearest')
-- luajs master : TypeError: Cannot read property 'metatable' of null
-- lua native : attempt to call field 'setDefaultImageFilter' (a nil value)
-- luajs changed (lualib.js only) : Error: attempt to call nil (undefined)
-- luajs changed (lualib.js + bison(see below)) : Error: attempt to call nil (lua_tableget(lua_tableget(_love_33, 'graphics'), 'setDefaultImageFilter)
```

bison : 
i don't know how to work with bison, so what i did was replace

```
case 91: this.$ = "lua_call( /*bla!*/ " + $$[$0-1].single + ", " + getTempDecl($$[$0]) + " )";
```

by

```
case 91: this.$ = "lua_call( /*bla!*/ " + $$[$0-1].single + ", " + getTempDecl($$[$0]) + ", "+longStringToString($$[$0-1].single)+")";
```

in the generated js code. ugly _ for example 2, and ugly js bulkwork around "setDefaultImageFilter" for example 3, but it already shows useful info and makes debugging a lot easier if you ask me.
i'm pretty sure it's in src/lua.jison Line 598 ff:

```
functioncall
  : prefixexp args { $$ = "lua_call(" + $1.single + ", " + getTempDecl($2) + ")"; } 
  | prefixexp ":" NAME args { $$ = "lua_mcall(" + $1.single + ", '" + $3 + "', " + getTempDecl($4) + ")"; }
  ;
```

any idea how to generate a useful 3rd "origin" parameter for lua_call here ? the 2nd case with lua_mcall already works (see example1), but i don't even know how to set up node.js/jison/... , so i cannot try it. 
plus i wouldn't even know what i would be doing. 
If field name is unavailable, chunkname+linenumber as text would be useful.
