### PR TITLE
getmetatable does not return list

### DIFF
--- a/src/lualib.js
+++ b/src/lualib.js
@@ -581,7 +581,7 @@ var lua_core = {
     not_supported();
   },
   "getmetatable": function (op) {
-    return op.metatable && (op.metatable.str["__metatable"] || op.metatable);
+    return [op.metatable && (op.metatable.str["__metatable"] || op.metatable)];
   },
   "ipairs": function (table) {
     return [_ipairs_next, table, 0];


### PR DESCRIPTION
getmetatable returns the metatable directly instead of putting it in a list. 
I assume that this is a bug and not intentional.
As far as I can see it caused issues in my code.
