### PR TITLE
tostring(), functions as keys

### DIFF
--- a/src/lualib.js
+++ b/src/lualib.js
@@ -660,7 +660,11 @@ var lua_core = {
     for (i in table.objs) {
       props.push(table.objs[i][0]);
     }
-
+	var funcs = table.bool[kFUNCS]
+    for (i in funcs) {
+	  props.push(funcs[i][0]);
+	}
+	
     // okay, so I'm faking it here
     // regardless of what key is given, this function will return the next value
     // not sure how to do it the "right way" right now


### PR DESCRIPTION
Hi.

I did a few things, trying to get some of my libraries to cooperate with the Love2D WebPlayer.

I depend in some places on functions as keys. Since that wasn't supported, I first used tostring() as a hack, appending an ID to "function" (and "table"). I'm VERY green on Javascript, so I'm not all that certain about what I did, but there it is.

Investigating, I saw that the only thing really holding back the functions was another array like "objs". Since you didn't add one, I decided to only load one on the fly... looking at it now, I guess I didn't need to put it in the bool object, but I figured we knew what keys that could hold and thus wouldn't stomp on anything. (As an aside, doing this, I did flush out that "bools" was used by accident in the pairs() function.)
So far, it looks like copying the "objs" logic in rawget() and rawset() was enough...

Last but not least (and I can post this as an issue if you'd prefer), this construct fails:

local ipairs = ipairs

since it resolves to something like "var _ipairs_63 = _ipairs_63;" and ends up null. It's easy to avoid (by just excising those parts from the files), but pretty annoying when one can't just drop in code.

Thanks!
- Steve
