### PR TITLE
`make; npm install -g` within git package dir fails

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,10 +25,8 @@
     "lua",
     "js"
   ],
-  "dependencies" : {
-    "jison"   :  "*"
-  },
   "devDependencies" : {
+    "jison"   :  "*",
     "mocha"   :  "*"
   },
   "license": "MIT",


### PR DESCRIPTION
Trying to install lua.js globally from within package directory (Git clone) fails with:

```
$ npm install -g
npm http GET https://registry.npmjs.org/jison
npm http 304 https://registry.npmjs.org/jison
npm http GET https://registry.npmjs.org/JSONSelect/0.4.0
npm http GET https://registry.npmjs.org/reflect/0.0.7
npm http GET https://registry.npmjs.org/nomnom/0.4.3
npm http 304 https://registry.npmjs.org/reflect/0.0.7
npm http 304 https://registry.npmjs.org/nomnom/0.4.3
npm http 304 https://registry.npmjs.org/JSONSelect/0.4.0
npm http GET https://registry.npmjs.org/underscore
npm http 304 https://registry.npmjs.org/underscore
npm ERR! Error: ENOENT, chmod '/home/miki/.local/lib/node_modules/lua.js/lua2js'
npm ERR! If you need help, you may report this log at:
npm ERR!     <http://github.com/isaacs/npm/issues>
npm ERR! or email it to:
npm ERR!     <npm-@googlegroups.com>

npm ERR! System Linux 3.5.0-18-generic
npm ERR! command "node" "/home/miki/.local/bin/npm" "install" "-g"
npm ERR! cwd /home/miki/vcs/git/node_modules/lua.js
npm ERR! node -v v0.9.4-pre
npm ERR! npm -v 1.1.66
npm ERR! path /home/miki/.local/lib/node_modules/lua.js/lua2js
npm ERR! code ENOENT
npm ERR! errno 34
npm ERR! 
npm ERR! Additional logging details can be found in:
npm ERR!     /home/miki/vcs/git/node_modules/lua.js/npm-debug.log
npm ERR! not ok code 0
```

(Note: prefix set to $HOME/.local for 'user-global' installs)
