### PR TITLE
Fix Lua operator overloading

### DIFF
--- a/src/lualib.js
+++ b/src/lualib.js
@@ -977,7 +977,7 @@ lua_libs["os"] = {
     if (table) {
       not_supported();
     } else {
-      return [new Date().getTime()]; // thanks ghoulsblade
+      return [Math.floor(new Date().getTime() / 1000)];
     }
   }
 };


### PR DESCRIPTION
Lua.js uses parseFloat to check whether the operand(s) are numbers or not and if  they are not, looks for operator overloading.

But while it checks for null, parseFloat actually returns NaN if the parsing failed see https://developer.mozilla.org/en-US/docs/JavaScript/Reference/Global_Objects/parseFloat#Description)

This pull request fixes the checks and make operator overloading actually work.
