### PR TITLE
Missing string functions + other fixes

### DIFF
--- a/src/lualib.js
+++ b/src/lualib.js
@@ -1480,7 +1480,17 @@ lua_libs["string"] = {
       if (replacementType == "string") {
         newMatchChunk = matchChunk.replace(regex, replacement);
       } else if (replacementType == "function") {
-        var result = replacement(match)[0]; // the function always returns an array
+        var result = null;
+        // match is the whole expression matched by the pattern, now get captures
+        var matches = match.match(pattern); // not global to get the captures !
+
+        if (matches[1] != null) {
+          matches = matches.slice(1);
+          result = replacement.apply(null, matches)[0];
+        } else {
+          result = replacement(match)[0]; // the function always returns an array
+        }
+        
         if (result == null) {
           newMatchChunk = matchChunk;
         } else {

--- a/tests/string.lua
+++ b/tests/string.lua
@@ -34,10 +34,11 @@ assert(r2 == "5 banana" and r3 == 1)
 r, r2 = string.gsub(s, "(a)", string.upper, 10) -- make all "a"s found uppercase
 assert(r == "Hello bAnAnA" and r2 == 3)
 
---r, r2 = string.gsub(s, "(a)(n)", function(a,b) return b..a end) -- reverse any "an"s
---assert(r == "Hello bnanaa" and r2 == 2)
--- function with two parameters are not supported
--- actually the capturing parenthesis are not supported with gsub, the whole matched expression is passed to the function
+r, r2 = string.gsub(s, "(a)(n)", function(a,b) return b..a end) -- reverse any "an"s
+assert(r == "Hello bnanaa" and r2 == 2)
+
+r, r2 = string.gsub(s, "a(n)", function(a) assert(a == "n"); return "ab" end) -- replace "n" by "b"
+assert(r == "Hello bababa" and r2 == 2)
 
 
 -- string.find(s, pattern[, index, plain])


### PR DESCRIPTION
Hey

I added the missing string functions : find, format, gsub, gmatch and match.
All cases of pattern translation I encountered are working OK (yet there are probably many cases that won't).

I also fixed several other functions like ensure_arraymode(), pairs(), tonumber(), os.clock().
