### PR TITLE
Update tonumber() to properly behave as in Lua :

### DIFF
--- a/src/lualib.js
+++ b/src/lualib.js
@@ -718,14 +718,27 @@ var lua_core = {
     return [table]
   },
   "tonumber": function (e, base) {
-    if (typeof e == "number") {
+    var type = typeof e;
+    if (type == "number") {
       return [e];
     }
-    if (base === 10 || base == null) {
-      return [parseFloat(e)];
-    } else {
-      return [parseInt(e, base)];
+    var isHex = false;
+    if (type == "string" && e.search("^\\s*0[xX][0-9A-Fa-f]+\\s*$") == 0) {
+      isHex = true;
     }
+    if (type != "string" || (!isHex && e.search("[^0-9\. -]") != -1)) {
+      return [null];
+    }
+    var num = null;
+    if ((base === 10 || base == null) && !isHex) {
+      num = parseFloat(e);
+    } else {
+      num = parseInt(e, base);
+    }
+    if (isNaN(num)) {
+      num = null;
+    }
+    return [num];
   },
   "tostring": function (e) {
     if (e == null) {

--- a/tests/tonumber.lua
+++ b/tests/tonumber.lua
@@ -1,0 +1,31 @@
+assert(tonumber(-5) == -5)
+assert(tonumber(-1.5) == -1.5)
+assert(tonumber(-0) == 0)
+assert(tonumber(0) == 0)
+assert(tonumber(5.46) == 5.46)
+assert(tonumber(21) == 21)
+
+assert(tonumber("-5") == -5)
+assert(tonumber("-1.5") == -1.5)
+assert(tonumber(" -0") == 0)
+assert(tonumber("0") == 0)
+assert(tonumber("5.46  ") == 5.46)
+assert(tonumber("   21  ") == 21)
+
+assert(tonumber("0xA") == 10)
+assert(tonumber("0XFF ") == 255)
+assert(tonumber("  0xB6F   ") == 2927)
+assert(tonumber(" 0XC2F3") == 49907)
+assert(tonumber("0x14BA2F") == 1358383)
+
+
+assert(tonumber("0XCZ2F3") == nil)
+assert(tonumber("456 0XC2F3") == nil)
+assert(tonumber("0x14BKA2F") == nil)
+assert(tonumber({}) == nil)
+assert(tonumber(false) == nil)
+assert(tonumber(nil) == nil)
+
+assert(tonumber("foo") == nil)
+assert(tonumber("789 foo") == nil)
+assert(tonumber("foo789") == nil)


### PR DESCRIPTION
- Return null instead of NaN whenever the 'e' argument is not a number or a string.
- Properly convert hex strings.
- Return null when a string (other than a hex number) contains any characters other than those found in digits + space.

Tests are included.
