### PR TITLE
Compatibility for Node v10

### DIFF
--- a/src/build_lua_parser.js
+++ b/src/build_lua_parser.js
@@ -1,7 +1,7 @@
 var fs = require("fs");
 var Generator = require("jison").Generator;
 var generator = new Generator(fs.readFileSync('src/lua.jison', 'utf8'), {type: "slr"})
-fs.writeFile("src/lua_parser.js", generator.generate({
+fs.writeFileSync("src/lua_parser.js", generator.generate({
   moduleType: "js",
   moduleName: "lua_parser",
 }));


### PR DESCRIPTION
Builds fail with Node v10+ due to an exception in `src/build_lua_parser.js` when calling `fs.writeFile()` without a callback at the 3rd argument.

In Node versions before v7, it was allowed not to pass a callback but this was deprecated in Node v7 and completely removed in Node v10.
While with v7, v8 and v9 skipping a callback would only issue a deprecation warning, v10 finalised the deprecations and it now throws an exception.

I updated the call to use `fs.writeFileSync()` instead, because it does not expect a callback and there was no special error handling in the code anyhow.